### PR TITLE
feat: add service provider domain model

### DIFF
--- a/src/main/java/com/carmarketplace/common/domain/provider/BusinessDetails.java
+++ b/src/main/java/com/carmarketplace/common/domain/provider/BusinessDetails.java
@@ -1,0 +1,60 @@
+package com.carmarketplace.common.domain.provider;
+
+import com.carmarketplace.common.domain.Guard;
+import java.util.List;
+
+/**
+ * Licensing and compliance information for a business.
+ */
+public class BusinessDetails {
+    private String businessLicense;
+    private String insuranceInfo;
+    private List<String> certifications;
+    private String taxInfo;
+
+    public BusinessDetails(String businessLicense,
+                           String insuranceInfo,
+                           List<String> certifications,
+                           String taxInfo) {
+        setBusinessLicense(businessLicense);
+        setInsuranceInfo(insuranceInfo);
+        setCertifications(certifications);
+        setTaxInfo(taxInfo);
+    }
+
+    public String getBusinessLicense() {
+        return businessLicense;
+    }
+
+    public void setBusinessLicense(String businessLicense) {
+        Guard.notBlank(businessLicense, "businessLicense");
+        this.businessLicense = businessLicense;
+    }
+
+    public String getInsuranceInfo() {
+        return insuranceInfo;
+    }
+
+    public void setInsuranceInfo(String insuranceInfo) {
+        Guard.notBlank(insuranceInfo, "insuranceInfo");
+        this.insuranceInfo = insuranceInfo;
+    }
+
+    public List<String> getCertifications() {
+        return certifications;
+    }
+
+    public void setCertifications(List<String> certifications) {
+        Guard.notNull(certifications, "certifications");
+        this.certifications = List.copyOf(certifications);
+    }
+
+    public String getTaxInfo() {
+        return taxInfo;
+    }
+
+    public void setTaxInfo(String taxInfo) {
+        Guard.notBlank(taxInfo, "taxInfo");
+        this.taxInfo = taxInfo;
+    }
+}

--- a/src/main/java/com/carmarketplace/common/domain/provider/Experience.java
+++ b/src/main/java/com/carmarketplace/common/domain/provider/Experience.java
@@ -1,0 +1,48 @@
+package com.carmarketplace.common.domain.provider;
+
+import com.carmarketplace.common.domain.Guard;
+import java.util.List;
+
+/**
+ * Professional experience information for a provider.
+ */
+public class Experience {
+    private int yearsOfExperience;
+    private List<String> portfolioUrls;
+    private List<String> references;
+
+    public Experience(int yearsOfExperience,
+                      List<String> portfolioUrls,
+                      List<String> references) {
+        setYearsOfExperience(yearsOfExperience);
+        setPortfolioUrls(portfolioUrls);
+        setReferences(references);
+    }
+
+    public int getYearsOfExperience() {
+        return yearsOfExperience;
+    }
+
+    public void setYearsOfExperience(int yearsOfExperience) {
+        Guard.nonNegative(yearsOfExperience, "yearsOfExperience");
+        this.yearsOfExperience = yearsOfExperience;
+    }
+
+    public List<String> getPortfolioUrls() {
+        return portfolioUrls;
+    }
+
+    public void setPortfolioUrls(List<String> portfolioUrls) {
+        Guard.notNull(portfolioUrls, "portfolioUrls");
+        this.portfolioUrls = List.copyOf(portfolioUrls);
+    }
+
+    public List<String> getReferences() {
+        return references;
+    }
+
+    public void setReferences(List<String> references) {
+        Guard.notNull(references, "references");
+        this.references = List.copyOf(references);
+    }
+}

--- a/src/main/java/com/carmarketplace/common/domain/provider/LocationType.java
+++ b/src/main/java/com/carmarketplace/common/domain/provider/LocationType.java
@@ -1,0 +1,9 @@
+package com.carmarketplace.common.domain.provider;
+
+/**
+ * Where services are delivered.
+ */
+public enum LocationType {
+    MOBILE,
+    WORKSHOP
+}

--- a/src/main/java/com/carmarketplace/common/domain/provider/MarketplaceCompliance.java
+++ b/src/main/java/com/carmarketplace/common/domain/provider/MarketplaceCompliance.java
@@ -1,0 +1,58 @@
+package com.carmarketplace.common.domain.provider;
+
+import com.carmarketplace.common.domain.Guard;
+import java.util.Map;
+
+/**
+ * Information required for operating within the marketplace.
+ */
+public class MarketplaceCompliance {
+    private Map<String, Object> paymentDetails;
+    private boolean agreedTerms;
+    private boolean identityVerified;
+    private String governmentIdUrl;
+
+    public MarketplaceCompliance(Map<String, Object> paymentDetails,
+                                 boolean agreedTerms,
+                                 boolean identityVerified,
+                                 String governmentIdUrl) {
+        setPaymentDetails(paymentDetails);
+        setAgreedTerms(agreedTerms);
+        setIdentityVerified(identityVerified);
+        setGovernmentIdUrl(governmentIdUrl);
+    }
+
+    public Map<String, Object> getPaymentDetails() {
+        return paymentDetails;
+    }
+
+    public void setPaymentDetails(Map<String, Object> paymentDetails) {
+        Guard.notNull(paymentDetails, "paymentDetails");
+        this.paymentDetails = Map.copyOf(paymentDetails);
+    }
+
+    public boolean isAgreedTerms() {
+        return agreedTerms;
+    }
+
+    public void setAgreedTerms(boolean agreedTerms) {
+        this.agreedTerms = agreedTerms;
+    }
+
+    public boolean isIdentityVerified() {
+        return identityVerified;
+    }
+
+    public void setIdentityVerified(boolean identityVerified) {
+        this.identityVerified = identityVerified;
+    }
+
+    public String getGovernmentIdUrl() {
+        return governmentIdUrl;
+    }
+
+    public void setGovernmentIdUrl(String governmentIdUrl) {
+        Guard.notBlank(governmentIdUrl, "governmentIdUrl");
+        this.governmentIdUrl = governmentIdUrl;
+    }
+}

--- a/src/main/java/com/carmarketplace/common/domain/provider/OperationalDetails.java
+++ b/src/main/java/com/carmarketplace/common/domain/provider/OperationalDetails.java
@@ -1,0 +1,73 @@
+package com.carmarketplace.common.domain.provider;
+
+import com.carmarketplace.common.domain.Guard;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Operational characteristics of a service provider.
+ */
+public class OperationalDetails {
+    private LocationType locationType;
+    private String workshopAddress;
+    private List<String> coverageArea;
+    private Map<String, String> operatingHours;
+    private ResponseTime responseTime;
+
+    public OperationalDetails(LocationType locationType,
+                              String workshopAddress,
+                              List<String> coverageArea,
+                              Map<String, String> operatingHours,
+                              ResponseTime responseTime) {
+        setLocationType(locationType);
+        setWorkshopAddress(workshopAddress);
+        setCoverageArea(coverageArea);
+        setOperatingHours(operatingHours);
+        setResponseTime(responseTime);
+    }
+
+    public LocationType getLocationType() {
+        return locationType;
+    }
+
+    public void setLocationType(LocationType locationType) {
+        Guard.notNull(locationType, "locationType");
+        this.locationType = locationType;
+    }
+
+    public String getWorkshopAddress() {
+        return workshopAddress;
+    }
+
+    public void setWorkshopAddress(String workshopAddress) {
+        Guard.notBlank(workshopAddress, "workshopAddress");
+        this.workshopAddress = workshopAddress;
+    }
+
+    public List<String> getCoverageArea() {
+        return coverageArea;
+    }
+
+    public void setCoverageArea(List<String> coverageArea) {
+        Guard.notNull(coverageArea, "coverageArea");
+        this.coverageArea = List.copyOf(coverageArea);
+    }
+
+    public Map<String, String> getOperatingHours() {
+        return operatingHours;
+    }
+
+    public void setOperatingHours(Map<String, String> operatingHours) {
+        Guard.notNull(operatingHours, "operatingHours");
+        this.operatingHours = Map.copyOf(operatingHours);
+    }
+
+    public ResponseTime getResponseTime() {
+        return responseTime;
+    }
+
+    public void setResponseTime(ResponseTime responseTime) {
+        Guard.notNull(responseTime, "responseTime");
+        this.responseTime = responseTime;
+    }
+}

--- a/src/main/java/com/carmarketplace/common/domain/provider/PriceType.java
+++ b/src/main/java/com/carmarketplace/common/domain/provider/PriceType.java
@@ -1,0 +1,10 @@
+package com.carmarketplace.common.domain.provider;
+
+/**
+ * How the price of a service is expressed.
+ */
+public enum PriceType {
+    FIXED,
+    HOURLY,
+    ESTIMATE
+}

--- a/src/main/java/com/carmarketplace/common/domain/provider/ResponseTime.java
+++ b/src/main/java/com/carmarketplace/common/domain/provider/ResponseTime.java
@@ -1,0 +1,10 @@
+package com.carmarketplace.common.domain.provider;
+
+/**
+ * Typical response time for a provider.
+ */
+public enum ResponseTime {
+    IMMEDIATE,
+    WITHIN_AN_HOUR,
+    SAME_DAY
+}

--- a/src/main/java/com/carmarketplace/common/domain/provider/Review.java
+++ b/src/main/java/com/carmarketplace/common/domain/provider/Review.java
@@ -1,0 +1,73 @@
+package com.carmarketplace.common.domain.provider;
+
+import com.carmarketplace.common.domain.Guard;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * A customer review of a service provider.
+ */
+public class Review {
+    private UUID id;
+    private UUID customerId;
+    private int rating;
+    private String comment;
+    private OffsetDateTime createdAt;
+
+    public Review(UUID id,
+                  UUID customerId,
+                  int rating,
+                  String comment,
+                  OffsetDateTime createdAt) {
+        setId(id);
+        setCustomerId(customerId);
+        setRating(rating);
+        setComment(comment);
+        setCreatedAt(createdAt);
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        Guard.notNull(id, "id");
+        this.id = id;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(UUID customerId) {
+        Guard.notNull(customerId, "customerId");
+        this.customerId = customerId;
+    }
+
+    public int getRating() {
+        return rating;
+    }
+
+    public void setRating(int rating) {
+        Guard.inRange(rating, 1, 5, "rating must be between 1 and 5");
+        this.rating = rating;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        Guard.notBlank(comment, "comment");
+        this.comment = comment;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        Guard.notNull(createdAt, "createdAt");
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/carmarketplace/common/domain/provider/ServiceCategory.java
+++ b/src/main/java/com/carmarketplace/common/domain/provider/ServiceCategory.java
@@ -1,0 +1,10 @@
+package com.carmarketplace.common.domain.provider;
+
+/**
+ * Categories of services a provider may offer.
+ */
+public enum ServiceCategory {
+    MAINTENANCE,
+    REPAIR,
+    INSPECTION
+}

--- a/src/main/java/com/carmarketplace/common/domain/provider/ServiceDetails.java
+++ b/src/main/java/com/carmarketplace/common/domain/provider/ServiceDetails.java
@@ -1,0 +1,101 @@
+package com.carmarketplace.common.domain.provider;
+
+import com.carmarketplace.common.domain.Guard;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Information about a specific service offered by a provider.
+ */
+public class ServiceDetails {
+    private UUID id;
+    private ServiceCategory category;
+    private String title;
+    private String description;
+    private PriceType priceType;
+    private BigDecimal priceValue;
+    private List<String> specialOffers;
+
+    public ServiceDetails(UUID id,
+                          ServiceCategory category,
+                          String title,
+                          String description,
+                          PriceType priceType,
+                          BigDecimal priceValue,
+                          List<String> specialOffers) {
+        setId(id);
+        setCategory(category);
+        setTitle(title);
+        setDescription(description);
+        setPriceType(priceType);
+        setPriceValue(priceValue);
+        setSpecialOffers(specialOffers);
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        Guard.notNull(id, "id");
+        this.id = id;
+    }
+
+    public ServiceCategory getCategory() {
+        return category;
+    }
+
+    public void setCategory(ServiceCategory category) {
+        Guard.notNull(category, "category");
+        this.category = category;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        Guard.notBlank(title, "title");
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        Guard.notBlank(description, "description");
+        this.description = description;
+    }
+
+    public PriceType getPriceType() {
+        return priceType;
+    }
+
+    public void setPriceType(PriceType priceType) {
+        Guard.notNull(priceType, "priceType");
+        this.priceType = priceType;
+    }
+
+    public BigDecimal getPriceValue() {
+        return priceValue;
+    }
+
+    public void setPriceValue(BigDecimal priceValue) {
+        Guard.notNull(priceValue, "priceValue");
+        if (priceValue.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("priceValue must be non-negative");
+        }
+        this.priceValue = priceValue;
+    }
+
+    public List<String> getSpecialOffers() {
+        return specialOffers;
+    }
+
+    public void setSpecialOffers(List<String> specialOffers) {
+        Guard.notNull(specialOffers, "specialOffers");
+        this.specialOffers = List.copyOf(specialOffers);
+    }
+}

--- a/src/main/java/com/carmarketplace/common/domain/provider/ServiceProvider.java
+++ b/src/main/java/com/carmarketplace/common/domain/provider/ServiceProvider.java
@@ -1,0 +1,169 @@
+package com.carmarketplace.common.domain.provider;
+
+import com.carmarketplace.common.domain.Guard;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Aggregate root representing a service provider in the marketplace.
+ */
+public class ServiceProvider {
+    private UUID id;
+    private String fullName;
+    private String contactPhone;
+    private String contactEmail;
+    private String address;
+    private String profilePictureUrl;
+    private String bio;
+    private BusinessDetails businessDetails;
+    private List<ServiceDetails> services;
+    private OperationalDetails operationalDetails;
+    private Experience experience;
+    private MarketplaceCompliance marketplaceCompliance;
+    private List<Review> reviews;
+
+    public ServiceProvider(UUID id,
+                           String fullName,
+                           String contactPhone,
+                           String contactEmail,
+                           String address,
+                           String profilePictureUrl,
+                           String bio,
+                           BusinessDetails businessDetails,
+                           List<ServiceDetails> services,
+                           OperationalDetails operationalDetails,
+                           Experience experience,
+                           MarketplaceCompliance marketplaceCompliance,
+                           List<Review> reviews) {
+        setId(id);
+        setFullName(fullName);
+        setContactPhone(contactPhone);
+        setContactEmail(contactEmail);
+        setAddress(address);
+        setProfilePictureUrl(profilePictureUrl);
+        setBio(bio);
+        setBusinessDetails(businessDetails);
+        setServices(services);
+        setOperationalDetails(operationalDetails);
+        setExperience(experience);
+        setMarketplaceCompliance(marketplaceCompliance);
+        setReviews(reviews);
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        Guard.notNull(id, "id");
+        this.id = id;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        Guard.notBlank(fullName, "fullName");
+        this.fullName = fullName;
+    }
+
+    public String getContactPhone() {
+        return contactPhone;
+    }
+
+    public void setContactPhone(String contactPhone) {
+        Guard.notBlank(contactPhone, "contactPhone");
+        this.contactPhone = contactPhone;
+    }
+
+    public String getContactEmail() {
+        return contactEmail;
+    }
+
+    public void setContactEmail(String contactEmail) {
+        Guard.notBlank(contactEmail, "contactEmail");
+        this.contactEmail = contactEmail;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        Guard.notBlank(address, "address");
+        this.address = address;
+    }
+
+    public String getProfilePictureUrl() {
+        return profilePictureUrl;
+    }
+
+    public void setProfilePictureUrl(String profilePictureUrl) {
+        Guard.notBlank(profilePictureUrl, "profilePictureUrl");
+        this.profilePictureUrl = profilePictureUrl;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public void setBio(String bio) {
+        Guard.notBlank(bio, "bio");
+        this.bio = bio;
+    }
+
+    public BusinessDetails getBusinessDetails() {
+        return businessDetails;
+    }
+
+    public void setBusinessDetails(BusinessDetails businessDetails) {
+        Guard.notNull(businessDetails, "businessDetails");
+        this.businessDetails = businessDetails;
+    }
+
+    public List<ServiceDetails> getServices() {
+        return services;
+    }
+
+    public void setServices(List<ServiceDetails> services) {
+        Guard.notNull(services, "services");
+        this.services = List.copyOf(services);
+    }
+
+    public OperationalDetails getOperationalDetails() {
+        return operationalDetails;
+    }
+
+    public void setOperationalDetails(OperationalDetails operationalDetails) {
+        Guard.notNull(operationalDetails, "operationalDetails");
+        this.operationalDetails = operationalDetails;
+    }
+
+    public Experience getExperience() {
+        return experience;
+    }
+
+    public void setExperience(Experience experience) {
+        Guard.notNull(experience, "experience");
+        this.experience = experience;
+    }
+
+    public MarketplaceCompliance getMarketplaceCompliance() {
+        return marketplaceCompliance;
+    }
+
+    public void setMarketplaceCompliance(MarketplaceCompliance marketplaceCompliance) {
+        Guard.notNull(marketplaceCompliance, "marketplaceCompliance");
+        this.marketplaceCompliance = marketplaceCompliance;
+    }
+
+    public List<Review> getReviews() {
+        return reviews;
+    }
+
+    public void setReviews(List<Review> reviews) {
+        Guard.notNull(reviews, "reviews");
+        this.reviews = List.copyOf(reviews);
+    }
+}

--- a/src/test/java/com/carmarketplace/common/domain/provider/ReviewTest.java
+++ b/src/test/java/com/carmarketplace/common/domain/provider/ReviewTest.java
@@ -1,0 +1,17 @@
+package com.carmarketplace.common.domain.provider;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReviewTest {
+
+    @Test
+    void ratingOutsideRangeThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new Review(UUID.randomUUID(), UUID.randomUUID(), 6, "bad", OffsetDateTime.now()));
+    }
+}

--- a/src/test/java/com/carmarketplace/common/domain/provider/ServiceDetailsTest.java
+++ b/src/test/java/com/carmarketplace/common/domain/provider/ServiceDetailsTest.java
@@ -1,0 +1,18 @@
+package com.carmarketplace.common.domain.provider;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ServiceDetailsTest {
+
+    @Test
+    void negativePriceThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new ServiceDetails(UUID.randomUUID(), ServiceCategory.MAINTENANCE, "t", "d", PriceType.FIXED, BigDecimal.valueOf(-1), List.of()));
+    }
+}

--- a/src/test/java/com/carmarketplace/common/domain/provider/ServiceProviderTest.java
+++ b/src/test/java/com/carmarketplace/common/domain/provider/ServiceProviderTest.java
@@ -1,0 +1,41 @@
+package com.carmarketplace.common.domain.provider;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ServiceProviderTest {
+
+    @Test
+    void blankFullNameThrows() {
+        BusinessDetails bd = new BusinessDetails("lic", "ins", List.of(), "tax");
+        ServiceDetails sd = new ServiceDetails(UUID.randomUUID(), ServiceCategory.MAINTENANCE, "title", "desc", PriceType.FIXED, BigDecimal.ONE, List.of());
+        OperationalDetails od = new OperationalDetails(LocationType.MOBILE, "addr", List.of(), Map.of(), ResponseTime.IMMEDIATE);
+        Experience exp = new Experience(1, List.of(), List.of());
+        MarketplaceCompliance mc = new MarketplaceCompliance(Map.of(), true, true, "id");
+        Review review = new Review(UUID.randomUUID(), UUID.randomUUID(), 5, "good", OffsetDateTime.now());
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new ServiceProvider(UUID.randomUUID(), " ", "p", "e", "a", "pic", "bio", bd, List.of(sd), od, exp, mc, List.of(review)));
+    }
+
+    @Test
+    void createsProvider() {
+        BusinessDetails bd = new BusinessDetails("lic", "ins", List.of("cert"), "tax");
+        ServiceDetails sd = new ServiceDetails(UUID.randomUUID(), ServiceCategory.REPAIR, "t", "d", PriceType.HOURLY, BigDecimal.TEN, List.of());
+        OperationalDetails od = new OperationalDetails(LocationType.WORKSHOP, "addr", List.of("area"), Map.of("mon", "9-5"), ResponseTime.SAME_DAY);
+        Experience exp = new Experience(5, List.of("url"), List.of("ref"));
+        MarketplaceCompliance mc = new MarketplaceCompliance(Map.of("acc", "123"), true, true, "id");
+        Review review = new Review(UUID.randomUUID(), UUID.randomUUID(), 4, "good", OffsetDateTime.now());
+
+        ServiceProvider provider = new ServiceProvider(UUID.randomUUID(), "John", "p", "e", "a", "pic", "bio", bd, List.of(sd), od, exp, mc, List.of(review));
+        assertEquals("John", provider.getFullName());
+        assertEquals(1, provider.getServices().size());
+    }
+}


### PR DESCRIPTION
## Summary
- model service provider aggregate with business, operational, experience, compliance, and review details
- define enums for service category, pricing, location type, and response time
- add tests covering provider construction and validation cases
- expose getters and setters for provider aggregate and related domain classes

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b27304d3c0832c9f0106d5e52cf19f